### PR TITLE
fix(docker): remove line preventing term signal on kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ ENV NGX_DISTRIBUTED_SHM_PORT=4321 \
 
 COPY target/ngx-distributed-shm.jar /
 
-STOPSIGNAL SIGRTMIN+3
-
 EXPOSE 4321
 
 ENTRYPOINT java -Dhazelcast.shutdownhook.policy=GRACEFUL \


### PR DESCRIPTION
Removed STOPSIGNAL SIGRTMIN+3 that prevents the sig_term signal to reach the java process and therefore prevent  the hazelcast gracefull shutdown.