### PR TITLE
build(hazelcast): fix log4shell on hazelcast

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
     <properties>
         <vertx.version>4.1.5</vertx.version>
-        <hazelcast.version>5.0</hazelcast.version>
+        <hazelcast.version>5.0.3</hazelcast.version>
         <slf4j.version>1.7.32</slf4j.version>
         <logback.version>1.2.6</logback.version>
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
Hazelcast has issued a fix for the Log4Shell vulnerability starting from 5.0.2, see [here](https://support.hazelcast.com/s/article/Security-Advisory-for-Log4Shell).
This PR is meant to update to the last 5.0.x version that includes the fix.