### PR TITLE
feat(#24): INCR with initial expiration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
+.idea/
 dependency-reduced-pom.xml
+*.iml

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=io.github.grrolland%3Angx-distributed-shm&metric=coverage)](https://sonarcloud.io/dashboard/index/io.github.grrolland:ngx-distributed-shm)
 [![Release](https://img.shields.io/github/release/grrolland/ngx-distributed-shm)](https://github.com/grrolland/ngx-distributed-shm/tags/)
 
-
 # ngx-distributed-shm
 
-This projet is memcached like server based on Hazelcast and Vertx. The goals of the project is to build an easy-to-use distributed memory storage with the nginx shared memory semantic for use with lua nginx plugin.
+This projet is memcached like server based on Hazelcast and Vertx. The goals of the project is to build an easy-to-use
+distributed memory storage with the nginx shared memory semantic for use with lua nginx plugin.
 
-The semantic of the protocol is the same as the [lua.shared](https://github.com/openresty/lua-nginx-module#ngxshareddict) semantic.
+The semantic of the protocol is the same as
+the [lua.shared](https://github.com/openresty/lua-nginx-module#ngxshareddict) semantic.
 
 ## Status
 
@@ -17,7 +18,8 @@ Production Ready since 06/2018.
 
 ## Use cases
 
-This project was successfully used to store rate limiting counter across a cluster of a Nginx based API Gateway in a French banking company.
+This project was successfully used to store rate limiting counter across a cluster of a Nginx based API Gateway in a
+French banking company.
 
 This project was successfully used to distribute OpenID Connect Replying Party (based on zmartzone/lua-resty-openidc
 ) web session with the library bungle/lua-resty-session in a french banking company.
@@ -66,7 +68,8 @@ Simply get the distribution jar and copy it on your filesystem.
 
 ## How it works
 
-When the storage startup, it creates an hazelcast instance and a vertx connector to communicate with it. When you start a second instance, it joins the first with the hazelcast protocol.
+When the storage startup, it creates an hazelcast instance and a vertx connector to communicate with it. When you start
+a second instance, it joins the first with the hazelcast protocol.
 
 The protocol expose commands to interact with the distributed storage :
 
@@ -76,7 +79,8 @@ The protocol expose commands to interact with the distributed storage :
 - DELETE : delete a key from the storage
 - INCR : increment the value for a key
 
-In a clustered deployment (2 or more instances), a client need to connect to only one instance to see all the storage. The goal is to provide a near storage associated with a nginx instance.
+In a clustered deployment (2 or more instances), a client need to connect to only one instance to see all the storage.
+The goal is to provide a near storage associated with a nginx instance.
 
 ## Startup
 
@@ -126,11 +130,13 @@ This command startup the storage on the 192.168.0.1 address :
 
 ### Configure the hazelcast IMDG map for replication
 
-The hazelcast IMDG is configured with a configuration file which must be present in the classpath. The file must be named hazelcast.xml.
+The hazelcast IMDG is configured with a configuration file which must be present in the classpath. The file must be
+named hazelcast.xml.
 
 This is an example of this file :
 
 ```xml
+
 <hazelcast xsi:schemaLocation="http://www.hazelcast.com/schema/config hazelcast-config-3.9.xsd"
            xmlns="http://www.hazelcast.com/schema/config"
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -141,7 +147,7 @@ This is an example of this file :
     <network>
         <port auto-increment="false">5701</port>
         <join>
-            <multicast enabled="false" />
+            <multicast enabled="false"/>
             <tcp-ip enabled="true">
                 <interface>10.0.x.y</interface>
                 <member-list>
@@ -149,7 +155,7 @@ This is an example of this file :
                     <member>10.0.x.z:5701</member>
                 </member-list>
             </tcp-ip>
-            <aws enabled="false" />
+            <aws enabled="false"/>
         </join>
     </network>
     <map name="default">
@@ -168,7 +174,8 @@ This is an example of this file :
 </hazelcast>
 ```
 
-The reference documentation for this configuration is here : <https://docs.hazelcast.org/docs/3.12.1/manual/html-single/index.html#tcp-ip-element>
+The reference documentation for this configuration is
+here : <https://docs.hazelcast.org/docs/3.12.1/manual/html-single/index.html#tcp-ip-element>
 
 This configuration works well for a two member cluster of the distributed shared memory.
 
@@ -183,7 +190,8 @@ The dist/conf directory contains an example logback.xml which control logging. T
     <contextName>ngx-dshm</contextName>
     <jmxConfigurator/>
 
-    <appender name="FILE-GLOBAL" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <appender name="FILE-GLOBAL"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
         <file>${ngx-distributed-shm.log_dir}/ngx-dshm.log</file>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>${ngx-distributed-shm.log_dir}/ngx-dshm-%d{yyyy-MM-dd}.log</fileNamePattern>
@@ -194,10 +202,10 @@ The dist/conf directory contains an example logback.xml which control logging. T
         </encoder>
     </appender>
 
-    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
-        <appender-ref ref="FILE-GLOBAL" />
+    <appender name="ASYNC"
+              class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="FILE-GLOBAL"/>
     </appender>
-
 
     <root level="info">
         <appender-ref ref="ASYNC"/>
@@ -226,7 +234,8 @@ The **_ARG1_** is alway the **_key_**
 
 ### Anatomy of a key : region cache support
 
-The distributed shared memory support region partitioning. The format of the key control the region where will be located the value.
+The distributed shared memory support region partitioning. The format of the key control the region where will be
+located the value.
 
 This key **_key1_** will be located in the region **_region1_** :
 
@@ -299,7 +308,8 @@ GET key\r\n
 
 **with data:** _yes_
 
-Set a value of length \<length\> for the key \<key\> in the storage with the expiration time in second \<expiration\>. This operation is atomic.
+Set a value of length \<length\> for the key \<key\> in the storage with the expiration time in second \<expiration\>.
+This operation is atomic.
 
 When \<expiration\> is 0, the key don't expire.
 
@@ -332,7 +342,7 @@ When the key does not exist the command does nothing.
 DELETE key\r\n
 ```
 
-**_INCR \<key\> \<value\> \<init\>_**
+**_INCR \<key\> \<value\> \<init\> \<initial_expiration\>_**
 
 **with data:** _no_
 
@@ -340,12 +350,17 @@ Increment the value of the key \<key\> with \<value\> if the key exists and repr
 
 If the value is not an integer, this operation has no effect.
 
-If the key don't exist or is expired, this operation create the key and init the value to \<value\>+\<init\>.
+If the key exist, initial_expiration has no effect.
+
+If the key don't exist or is expired, this operation create the key and init the value to \<value\>+\<init\>. In that
+case, if initial_expiration is not provided or 0, the key will never expire
 
 This operation is atomic.
 
 ```
 INCR key -1 0\r\n
+
+INCR key -1 0 60\r\n
 ```
 
 **_FLUSHALL [region]_**
@@ -378,7 +393,8 @@ QUIT\r\n
 
 ## LUA libraries support
 
-The lua libraries (lua/dshm.lua) is used to pilot the shared memory. The library should be installed in the resty directory of the openresty distribution.
+The lua libraries (lua/dshm.lua) is used to pilot the shared memory. The library should be installed in the resty
+directory of the openresty distribution.
 
 This is an exemple to use it :
 
@@ -397,9 +413,11 @@ store:delete("key")
 
 ### Resty Session support
 
-This module could be used to activate session replication with the excellent lua library Resty Session (<https://github.com/bungle/lua-resty-session>)
+This module could be used to activate session replication with the excellent lua library Resty
+Session (<https://github.com/bungle/lua-resty-session>)
 
-To use it, copy the lua extension in your resty/session/storage directory and use this type of configuration in your nginx.conf :
+To use it, copy the lua extension in your resty/session/storage directory and use this type of configuration in your
+nginx.conf :
 
 ```nginx
 set $session_storage               dshm;
@@ -447,22 +465,25 @@ The session_storage parameter control the storage module to be used.
     ```shell
     docker pull ghcr.io/grrolland/ngx-distributed-shm    
     ```
+
 ## Kubernetes
 
 1. See [kubernetes](./kubernetes) directory for sample artefacts.
-2. Use [kustomize](https://github.com/kubernetes-sigs/kustomize) standalone or the one embedded in `kubectl` to generate kubernetes artefacts for a specific release:
+2. Use [kustomize](https://github.com/kubernetes-sigs/kustomize) standalone or the one embedded in `kubectl` to generate
+   kubernetes artefacts for a specific release:
 
-   - Change files in `kubernetes/overlays/test/` according to your needs
-     - `configmap.yaml` contains a basic hazelcast configuration as yaml instead of xml for ease of reading
-   - Generate artefacts and inspect:
+    - Change files in `kubernetes/overlays/test/` according to your needs
+        - `configmap.yaml` contains a basic hazelcast configuration as yaml instead of xml for ease of reading
+    - Generate artefacts and inspect:
 
-     ```bash
-     cd kubernetes
-     kubectl kustomize /overlays/test > kubernetes.yaml
-     ```
+      ```bash
+      cd kubernetes
+      kubectl kustomize /overlays/test > kubernetes.yaml
+      ```
 
-   - Apply: `kubectl apply -f kubernetes.yaml`
+    - Apply: `kubectl apply -f kubernetes.yaml`
 
 ## Management Center
 
-- Optionally, the Hazelcast cluster can be monitored via [Management Center](https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html)
+- Optionally, the Hazelcast cluster can be monitored
+  via [Management Center](https://docs.hazelcast.org/docs/management-center/latest/manual/html/index.html)

--- a/lua/dshm.lua
+++ b/lua/dshm.lua
@@ -1,4 +1,3 @@
-
 local escape_uri = ngx.escape_uri
 local unescape_uri = ngx.unescape_uri
 local match = string.match
@@ -120,7 +119,7 @@ function _M.get(self, key)
         return nil, "not initialized"
     end
 
-    local bytes, err = sock:send("get " .. self.escape_key(key) .. "\r\n" )
+    local bytes, err = sock:send("get " .. self.escape_key(key) .. "\r\n")
     if not bytes then
         return nil, err
     end
@@ -150,7 +149,6 @@ function _M.get(self, key)
 
 end
 
-
 function _M.delete(self, key)
 
     ngx.log(ngx.DEBUG, "Delete : ", key)
@@ -160,7 +158,7 @@ function _M.delete(self, key)
         return nil, "not initialized"
     end
 
-    local bytes, err = sock:send("delete " .. self.escape_key(key) .. "\r\n" )
+    local bytes, err = sock:send("delete " .. self.escape_key(key) .. "\r\n")
     if not bytes then
         return nil, err
     end
@@ -176,10 +174,9 @@ function _M.delete(self, key)
 
 end
 
+function _M.incr(self, key, value, init, init_ttl)
 
-function _M.incr(self, key, value, init)
-
-    ngx.log(ngx.DEBUG, "Incr : ", key, ", Value : ", value, ", Init : ", init)
+    ngx.log(ngx.DEBUG, "Incr : ", key, ", Value : ", value, ", Init : ", init, ", Init_TTL", init_ttl)
 
     local sock = self.sock
     if not sock then
@@ -191,7 +188,13 @@ function _M.incr(self, key, value, init)
         l_init = init
     end
 
-    local bytes, err = sock:send("incr " .. self.escape_key(key) .. " " .. value .. " " .. l_init .. "\r\n")
+    local s_init_ttl = ""
+    if init_ttl then
+        s_init_ttl = " " .. init_ttl
+    end
+
+    local command = "incr " .. self.escape_key(key) .. " " .. value .. " " .. l_init .. s_init_ttl .. "\r\n"
+    local bytes, err = sock:send(command)
     if not bytes then
         return nil, err
     end
@@ -261,7 +264,6 @@ function _M.set(self, key, value, exptime)
 
 end
 
-
 function _M.touch(self, key, exptime)
 
     if not exptime or exptime == 0 then
@@ -294,7 +296,6 @@ function _M.touch(self, key, exptime)
     end
 
 end
-
 
 function _M.quit(self)
     local sock = self.sock
@@ -337,7 +338,6 @@ function _M.set_keepalive(self, ...)
 
     return sock:setkeepalive(...)
 end
-
 
 function _M.get_reused_times(self)
     local sock = self.sock

--- a/src/main/java/io/github/grrolland/hcshm/ShmService.java
+++ b/src/main/java/io/github/grrolland/hcshm/ShmService.java
@@ -1,28 +1,26 @@
 /**
  * ngx-distributed-shm
  * Copyright (C) 2018  Flu.Tech
- *
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package io.github.grrolland.hcshm;
 
-
-
-import io.github.grrolland.hcshm.processor.IncrProcessor;
-import io.github.grrolland.hcshm.processor.TouchProcessor;
 import com.hazelcast.core.HazelcastInstance;
 import com.hazelcast.map.IMap;
+import io.github.grrolland.hcshm.processor.IncrProcessor;
+import io.github.grrolland.hcshm.processor.TouchProcessor;
 
 import java.util.concurrent.TimeUnit;
 
@@ -34,50 +32,48 @@ public class ShmService {
     /**
      * The HAzelcast Instance
      */
-    private HazelcastInstance hazelcast;
+    private final HazelcastInstance hazelcast;
 
     /**
      * Region Locator
      */
-    private ShmRegionLocator regionLocator = new ShmRegionLocator();
+    private final ShmRegionLocator regionLocator = new ShmRegionLocator();
 
     /**
      * Public Constructor
-     * @param hazelcast the hazelcast instance
+     *
+     * @param hazelcast
+     *         the hazelcast instance
      */
     public ShmService(HazelcastInstance hazelcast) {
         this.hazelcast = hazelcast;
     }
 
     /**
-     * Get the map form the key name
-     * @param key the key
-     * @return return the named IMap, if no region in the key return the default IMap
-     */
-    private IMap<String, ShmValue> getMap(final String key) {
-        return regionLocator.getMap(hazelcast, key);
-    }
-
-    /**
      * Get Operation
-     * @param key the key
+     *
+     * @param key
+     *         the key
      * @return the value as string or the error
      */
     public String get(String key) {
         ShmValue r = getMap(key).get(key);
         if (null != r) {
-            return r.getValue() ;
-        }
-        else{
+            return r.getValue();
+        } else {
             return null;
         }
     }
 
     /**
      * The Set operation for string value
-     * @param key the key
-     * @param value the value as string
-     * @param expire the expiration in seconds
+     *
+     * @param key
+     *         the key
+     * @param value
+     *         the value as string
+     * @param expire
+     *         the expiration in seconds
      * @return the value set
      */
     public String set(String key, String value, int expire) {
@@ -87,21 +83,28 @@ public class ShmService {
 
     /**
      * The Set operation for long value
-     * @param key the key
-     * @param value the value as long
-     * @param expire the expiration in seconds
+     *
+     * @param key
+     *         the key
+     * @param value
+     *         the value as long
+     * @param expire
+     *         the expiration in seconds
      * @return the value set as string representation
      */
     public String set(String key, long value, int expire) {
-        String r =   Long.toString(value);
+        String r = Long.toString(value);
         getMap(key).set(key, new ShmValue(r, expire), expire, TimeUnit.SECONDS);
         return r;
     }
 
     /**
      * The touch operation
-     * @param key the key
-     * @param expire the expiration in seconds
+     *
+     * @param key
+     *         the key
+     * @param expire
+     *         the expiration in seconds
      */
     public void touch(String key, int expire) {
         getMap(key).executeOnKey(key, new TouchProcessor(expire));
@@ -109,18 +112,26 @@ public class ShmService {
 
     /**
      * The incr operation
-     * @param key the key
-     * @param value the increment
-     * @param init the init value
+     *
+     * @param key
+     *         the key
+     * @param value
+     *         the increment
+     * @param init
+     *         the init value
+     * @param initialExpire
+     *         the initial expiration
      * @return the new value as string representation
      */
-    public String incr(String key, int value, int init) {
-        return (String) getMap(key).executeOnKey(key, new IncrProcessor(value, init));
+    public String incr(String key, int value, int init, int initialExpire) {
+        return (String) getMap(key).executeOnKey(key, new IncrProcessor(value, init, initialExpire));
     }
 
     /**
      * The delete operation
-     * @param key the key to delete
+     *
+     * @param key
+     *         the key to delete
      */
     public void delete(String key) {
         getMap(key).delete(key);
@@ -128,10 +139,23 @@ public class ShmService {
 
     /**
      * Remove all entries from the region by clearing the map cluster wide
-     * @param region the region name
+     *
+     * @param region
+     *         the region name
      */
     public void flushall(String region) {
         regionLocator.getMapRegion(hazelcast, region).clear();
+    }
+
+    /**
+     * Get the map form the key name
+     *
+     * @param key
+     *         the key
+     * @return return the named IMap, if no region in the key return the default IMap
+     */
+    private IMap<String, ShmValue> getMap(final String key) {
+        return regionLocator.getMap(hazelcast, key);
     }
 
 }

--- a/src/main/java/io/github/grrolland/hcshm/commands/IncrCommand.java
+++ b/src/main/java/io/github/grrolland/hcshm/commands/IncrCommand.java
@@ -1,17 +1,17 @@
 /**
  * ngx-distributed-shm
  * Copyright (C) 2018  Flu.Tech
- *
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
@@ -27,7 +27,9 @@ public class IncrCommand extends Command {
 
     /**
      * Default Constructor
-     * @param service the shm service
+     *
+     * @param service
+     *         the shm service
      */
     IncrCommand(ShmService service) {
         super(service);
@@ -35,24 +37,24 @@ public class IncrCommand extends Command {
 
     /**
      * Execute the command
-     * @param commandTokens the protocol tokens argument of the command
+     *
+     * @param commandTokens
+     *         the protocol tokens argument of the command
      * @return the result of the command 'protocol encoded'
      */
     public String execute(String[] commandTokens) {
         final StringBuilder response = new StringBuilder();
-        try
-        {
-            assertTokens(commandTokens, 4);
+        try {
+            assertTokens(commandTokens, 4, 5);
             String key = getKey(commandTokens[1]);
             int incr = getIncrValue(commandTokens[2]);
             int initial = getIncrValue(commandTokens[3]);
-            String value = getService().incr(key, incr, initial);
+            int initialExpire = commandTokens.length == 5 ? getExpire(commandTokens[4]) : 0;
+            String value = getService().incr(key, incr, initial, initialExpire);
             writeLen(response, value);
             writeValue(response, value);
             writeDone(response);
-        }
-        catch (ProtocolException e)
-        {
+        } catch (ProtocolException e) {
             writeMalformedRequest(response);
         }
         return response.toString();

--- a/src/main/java/io/github/grrolland/hcshm/processor/IncrProcessor.java
+++ b/src/main/java/io/github/grrolland/hcshm/processor/IncrProcessor.java
@@ -1,27 +1,27 @@
 /**
  * ngx-distributed-shm
  * Copyright (C) 2018  Flu.Tech
- *
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package io.github.grrolland.hcshm.processor;
 
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.map.IMap;
 import io.github.grrolland.hcshm.HazelcastInstanceHandler;
 import io.github.grrolland.hcshm.ShmRegionLocator;
 import io.github.grrolland.hcshm.ShmValue;
-import com.hazelcast.map.IMap;
-import com.hazelcast.map.EntryProcessor;
 
 import java.io.Serializable;
 import java.util.Map;
@@ -34,57 +34,66 @@ public class IncrProcessor implements EntryProcessor<String, ShmValue, Object>, 
     /**
      * Incrementation value
      */
-    private long value = 0;
+    private final long value;
+
     /**
      * Initial value
      */
-    private int init = 0;
+    private final int init;
+
+    /**
+     * Initial TTL value
+     */
+    private final int initialExpire;
+
     /**
      * Region locator
      */
-    private ShmRegionLocator regionLocator = new ShmRegionLocator();
+    private final ShmRegionLocator regionLocator = new ShmRegionLocator();
 
     /**
      * Constructor
-     * @param value incrementation value
-     * @param init initial value
+     *
+     * @param value
+     *         incrementation value
+     * @param init
+     *         initial value
+     * @param initialExpire
+     *         the initial expiration
      */
-    public IncrProcessor(long value, int init) {
-        this.value= value;
+    public IncrProcessor(long value, int init, int initialExpire) {
+        this.value = value;
         this.init = init;
+        this.initialExpire = initialExpire;
     }
 
     /**
      * Process  the incrementation command
-     * @param entry the entry to increment
+     *
+     * @param entry
+     *         the entry to increment
      * @return the new value
      */
     @Override
     public Object process(Map.Entry<String, ShmValue> entry) {
         final ShmValue r = entry.getValue();
-        String newval = null;
-        int expire = 0;
+        String newval;
+        int expire;
         if (null != r) {
-            try
-            {
+            try {
                 newval = Long.toString(Long.parseLong(r.getValue()) + value);
-            }
-            catch (NumberFormatException e)
-            {
+            } catch (NumberFormatException e) {
                 newval = r.getValue();
             }
             expire = r.getLastingTime();
-        }
-        else
-        {
+        } else {
             newval = Long.toString(value + init);
+            expire = this.initialExpire;
         }
         IMap<String, ShmValue> map = regionLocator.getMap(HazelcastInstanceHandler.getInstance(), entry.getKey());
         if (expire >= 0) {
             map.set(entry.getKey(), new ShmValue(newval, expire), expire, TimeUnit.SECONDS);
-        }
-        else
-        {
+        } else {
             map.remove(entry.getKey());
         }
         return newval;

--- a/src/test/java/io/github/grrolland/hcshm/AbstractHCSHMGetTestCase.java
+++ b/src/test/java/io/github/grrolland/hcshm/AbstractHCSHMGetTestCase.java
@@ -63,7 +63,7 @@ public abstract class AbstractHCSHMGetTestCase {
     @Before
     public void before() {
         try {
-            Socket sock = new Socket(InetAddress.getByName("localhost"), 4321);
+            Socket sock = new Socket(InetAddress.getByName("localhost"), 40321);
             reader = new BufferedReader(new InputStreamReader(sock.getInputStream()));
             writer = new BufferedWriter(new OutputStreamWriter(sock.getOutputStream()));
             flush();

--- a/src/test/java/io/github/grrolland/hcshm/AbstractHCSHMGetTestCase.java
+++ b/src/test/java/io/github/grrolland/hcshm/AbstractHCSHMGetTestCase.java
@@ -1,29 +1,31 @@
 /**
  * ngx-distributed-shm
  * Copyright (C) 2018  Flu.Tech
- *
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package io.github.grrolland.hcshm;
 
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
 
-import ch.qos.logback.classic.Level;
-import ch.qos.logback.classic.Logger;
-import org.junit.*;
-import org.slf4j.LoggerFactory;
-
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
 import java.net.InetAddress;
 import java.net.Socket;
 
@@ -35,7 +37,7 @@ public abstract class AbstractHCSHMGetTestCase {
     /**
      * Test Socket
      */
-    private Socket sock = null;
+    private final Socket sock = null;
 
     /**
      * Socket Reader
@@ -47,20 +49,51 @@ public abstract class AbstractHCSHMGetTestCase {
      */
     private BufferedWriter writer = null;
 
+    protected BufferedReader getReader() {
+        return reader;
+    }
+
+    protected BufferedWriter getWriter() {
+        return writer;
+    }
+
     /**
      * Init Socket, Reader and Writer
      */
     @Before
     public void before() {
         try {
-            Socket sock = new Socket(InetAddress.getByName("localhost"), 40321);
+            Socket sock = new Socket(InetAddress.getByName("localhost"), 4321);
             reader = new BufferedReader(new InputStreamReader(sock.getInputStream()));
             writer = new BufferedWriter(new OutputStreamWriter(sock.getOutputStream()));
-        }
-        catch (IOException e)
-        {
+            flush();
+        } catch (IOException e) {
             e.printStackTrace();
         }
+    }
+
+    /**
+     * Flush default region
+     *
+     * @throws IOException
+     *         I/O exception
+     */
+    public void flush() throws IOException {
+        this.flush("");
+    }
+
+    /**
+     * Flush ALL region
+     *
+     * @param region
+     *         the region
+     * @throws IOException
+     *         I/O exception
+     */
+    public void flush(String region) throws IOException {
+        getWriter().write(String.format("FLUSHALL %s\r\n", region));
+        getWriter().flush();
+        getReader().readLine();
     }
 
     /**
@@ -80,19 +113,25 @@ public abstract class AbstractHCSHMGetTestCase {
                 sock.shutdownOutput();
                 sock.close();
             }
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             e.printStackTrace();
         }
     }
 
-    protected BufferedReader getReader() {
-        return reader;
+    /**
+     * Assert a value is read
+     *
+     * @param expect
+     *         expected value
+     * @throws IOException
+     *         I/O Exception
+     */
+    public void assertGetValue(String expect) throws IOException {
+        String res = getReader().readLine();
+        Assert.assertEquals("LEN " + expect.length(), res);
+        res = getReader().readLine();
+        Assert.assertEquals(expect, res);
+        res = getReader().readLine();
+        Assert.assertEquals("DONE", res);
     }
-
-    protected BufferedWriter getWriter() {
-        return writer;
-    }
-
 }

--- a/src/test/java/io/github/grrolland/hcshm/IncrTestCase.java
+++ b/src/test/java/io/github/grrolland/hcshm/IncrTestCase.java
@@ -1,22 +1,21 @@
 /**
  * ngx-distributed-shm
  * Copyright (C) 2018  Flu.Tech
- *
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
 package io.github.grrolland.hcshm;
-
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -26,8 +25,8 @@ import java.io.IOException;
 /**
  * Global Protocol Test Case
  */
-public class IncrTestCase extends  AbstractHCSHMGetTestCase {
- 
+public class IncrTestCase extends AbstractHCSHMGetTestCase {
+
     /**
      * Test Incrementation
      */
@@ -38,34 +37,79 @@ public class IncrTestCase extends  AbstractHCSHMGetTestCase {
             getWriter().write("SET key 0 10\r\n");
             getWriter().write("1234567890");
             getWriter().flush();
-            String res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("1234567890", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("1234567890");
 
             getWriter().write("INCR key 1 0\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("1234567891", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("1234567891");
 
             getWriter().write("GET key\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("1234567891", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("1234567891");
 
+        } catch (IOException e) {
+            Assert.fail(e.getMessage());
         }
-        catch (IOException e)
-        {
+
+    }
+
+    /**
+     * Test Incrementation
+     */
+    @Test
+    public void testIncrExpire() {
+
+        try {
+            // Icrement testIncrExpire
+            getWriter().write("INCR key -1 10 2\r\n");
+            getWriter().flush();
+            assertGetValue("9");
+
+            getWriter().write("GET key\r\n");
+            getWriter().flush();
+            assertGetValue("9");
+
+            Thread.sleep(3000); // NOSONAR
+            getWriter().write("GET key\r\n");
+            getWriter().flush();
+            String res = getReader().readLine();
+            Assert.assertEquals("ERROR not_found", res);
+
+        } catch (IOException | InterruptedException e) {
+            Assert.fail(e.getMessage());
+        }
+
+    }
+
+    /**
+     * Test Incrementation
+     */
+    @Test
+    public void testIncrExistingWithExpire() {
+
+        try {
+            // Increment testIncrExpire
+            getWriter().write("SET key 0 2\r\n");
+            getWriter().write("10");
+            getWriter().flush();
+            assertGetValue("10");
+
+            getWriter().write("INCR key -1 10 2\r\n");
+            getWriter().flush();
+            assertGetValue("9");
+
+            getWriter().write("GET key\r\n");
+            getWriter().flush();
+            assertGetValue("9");
+
+            // Key should not expire
+            Thread.sleep(3000); // NOSONAR
+
+            getWriter().write("GET key\r\n");
+            getWriter().flush();
+            assertGetValue("9");
+
+        } catch (IOException | InterruptedException e) {
             Assert.fail(e.getMessage());
         }
 
@@ -81,34 +125,17 @@ public class IncrTestCase extends  AbstractHCSHMGetTestCase {
             getWriter().write("SET region:key 0 10\r\n");
             getWriter().write("1234567890");
             getWriter().flush();
-            String res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("1234567890", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("1234567890");
 
             getWriter().write("INCR region:key 1 0\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("1234567891", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("1234567891");
 
             getWriter().write("GET region:key\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("1234567891", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("1234567891");
 
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
 
@@ -124,34 +151,17 @@ public class IncrTestCase extends  AbstractHCSHMGetTestCase {
             getWriter().write("SET key 0 10\r\n");
             getWriter().write("AZERTYUIOP");
             getWriter().flush();
-            String res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("AZERTYUIOP", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("AZERTYUIOP");
 
             getWriter().write("INCR key 1 0\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("AZERTYUIOP", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("AZERTYUIOP");
 
             getWriter().write("GET key\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("AZERTYUIOP", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("AZERTYUIOP");
 
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
 
@@ -167,34 +177,17 @@ public class IncrTestCase extends  AbstractHCSHMGetTestCase {
             getWriter().write("SET region:key 0 10\r\n");
             getWriter().write("AZERTYUIOP");
             getWriter().flush();
-            String res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("AZERTYUIOP", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("AZERTYUIOP");
 
             getWriter().write("INCR region:key 1 0\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("AZERTYUIOP", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("AZERTYUIOP");
 
             getWriter().write("GET region:key\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 10", res);
-            res = getReader().readLine();
-            Assert.assertEquals("AZERTYUIOP", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("AZERTYUIOP");
 
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
 
@@ -210,25 +203,13 @@ public class IncrTestCase extends  AbstractHCSHMGetTestCase {
 
             getWriter().write("INCR newkey 1 10\r\n");
             getWriter().flush();
-            String res = getReader().readLine();
-            Assert.assertEquals("LEN 2", res);
-            res = getReader().readLine();
-            Assert.assertEquals("11", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("11");
 
             getWriter().write("GET newkey\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 2", res);
-            res = getReader().readLine();
-            Assert.assertEquals("11", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("11");
 
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
 
@@ -241,28 +222,16 @@ public class IncrTestCase extends  AbstractHCSHMGetTestCase {
     public void testRegionIncrInit() {
 
         try {
-
+            this.flush("region");
             getWriter().write("INCR region:newkey 1 10\r\n");
             getWriter().flush();
-            String res = getReader().readLine();
-            Assert.assertEquals("LEN 2", res);
-            res = getReader().readLine();
-            Assert.assertEquals("11", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("11");
 
             getWriter().write("GET region:newkey\r\n");
             getWriter().flush();
-            res = getReader().readLine();
-            Assert.assertEquals("LEN 2", res);
-            res = getReader().readLine();
-            Assert.assertEquals("11", res);
-            res = getReader().readLine();
-            Assert.assertEquals("DONE", res);
+            assertGetValue("11");
 
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
 
@@ -280,9 +249,7 @@ public class IncrTestCase extends  AbstractHCSHMGetTestCase {
             String res = getReader().readLine();
             Assert.assertEquals("ERROR malformed_request", res);
 
-        }
-        catch (IOException e)
-        {
+        } catch (IOException e) {
             Assert.fail(e.getMessage());
         }
 


### PR DESCRIPTION
Implementation of #24 

The [lua.shared](https://github.com/openresty/lua-nginx-module#ngxshareddict) semantic has evolved. The method [incr](https://github.com/openresty/lua-nginx-module#ngxshareddictincr) now accept an optional parameter init_ttl :

`syntax: newval, err, forcible? = ngx.shared.DICT:incr(key, value, init?, init_ttl?)`

init_ttl allow to create the missing key with a ttl and avoid to make another call to handle expiration (incr than expire)

`remaining, err = dict:incr(key, -1, limit, window)`

A new parameter has been added to INCR command in order to be compliant with lua.shared.DICT